### PR TITLE
feat: add prompt loader utility (#26)

### DIFF
--- a/src/core/prompt-loader.test.ts
+++ b/src/core/prompt-loader.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { loadPrompts } from "./prompt-loader.js";
+
+const TEST_DIR = resolve(import.meta.dirname, "../../.test-prompts");
+
+describe("loadPrompts", () => {
+  beforeEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it("returns empty prompt when directory does not exist", () => {
+    const result = loadPrompts(resolve(TEST_DIR, "nonexistent"));
+    expect(result.prompt).toBe("");
+    expect(result.files).toEqual([]);
+  });
+
+  it("returns empty prompt when directory is empty", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const result = loadPrompts(TEST_DIR);
+    expect(result.prompt).toBe("");
+    expect(result.files).toEqual([]);
+  });
+
+  it("loads a single .md file", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "SOUL.md"), "You are helpful.");
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.prompt).toBe("You are helpful.");
+    expect(result.files).toEqual(["SOUL.md"]);
+  });
+
+  it("loads multiple .md files in alphabetical order", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "TOOLS.md"), "Use web_search.");
+    writeFileSync(resolve(TEST_DIR, "SOUL.md"), "Be friendly.");
+    writeFileSync(resolve(TEST_DIR, "CONTEXT.md"), "User is Filip.");
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.files).toEqual(["CONTEXT.md", "SOUL.md", "TOOLS.md"]);
+    expect(result.prompt).toBe(
+      "User is Filip.\n\nBe friendly.\n\nUse web_search."
+    );
+  });
+
+  it("ignores non-.md files", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "SOUL.md"), "Hello.");
+    writeFileSync(resolve(TEST_DIR, "notes.txt"), "Ignored.");
+    writeFileSync(resolve(TEST_DIR, "config.json"), "{}");
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.files).toEqual(["SOUL.md"]);
+    expect(result.prompt).toBe("Hello.");
+  });
+
+  it("skips empty .md files without adding blank fragments", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "A.md"), "First.");
+    writeFileSync(resolve(TEST_DIR, "B.md"), "   \n  \n  ");
+    writeFileSync(resolve(TEST_DIR, "C.md"), "Third.");
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.files).toEqual(["A.md", "B.md", "C.md"]);
+    expect(result.prompt).toBe("First.\n\nThird.");
+  });
+
+  it("trims whitespace from file contents", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "SOUL.md"), "\n  Hello world.  \n\n");
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.prompt).toBe("Hello world.");
+  });
+
+  it("handles case-insensitive .MD extension", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "README.MD"), "Upper case ext.");
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.files).toEqual(["README.MD"]);
+    expect(result.prompt).toBe("Upper case ext.");
+  });
+
+  it("returns empty prompt when path is a file, not a directory", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    const filePath = resolve(TEST_DIR, "not-a-dir.txt");
+    writeFileSync(filePath, "I am a file");
+
+    const result = loadPrompts(filePath);
+    expect(result.prompt).toBe("");
+    expect(result.files).toEqual([]);
+  });
+
+  it("skips unreadable .md files without crashing", () => {
+    mkdirSync(TEST_DIR, { recursive: true });
+    writeFileSync(resolve(TEST_DIR, "A.md"), "First.");
+    writeFileSync(resolve(TEST_DIR, "B.md"), "Second.");
+
+    // Make B.md unreadable (only works on Unix-like systems)
+    const { chmodSync } = require("node:fs");
+    chmodSync(resolve(TEST_DIR, "B.md"), 0o000);
+
+    const result = loadPrompts(TEST_DIR);
+    expect(result.files).toEqual(["A.md", "B.md"]);
+    // Should still have the readable file's content
+    expect(result.prompt).toContain("First.");
+
+    // Restore permissions for cleanup
+    chmodSync(resolve(TEST_DIR, "B.md"), 0o644);
+  });
+});

--- a/src/core/prompt-loader.ts
+++ b/src/core/prompt-loader.ts
@@ -1,0 +1,65 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { resolve, extname } from "node:path";
+
+export interface LoadPromptsResult {
+  /** Concatenated prompt text from all .md files */
+  prompt: string;
+  /** List of filenames that were loaded (in order) */
+  files: string[];
+}
+
+/**
+ * Load all .md files from a directory and concatenate them into a system prompt.
+ * Files are read in alphabetical order and joined with double newlines.
+ *
+ * Returns an empty prompt (no error) if the directory is missing, empty,
+ * not a directory, or unreadable.
+ */
+export function loadPrompts(promptsDir: string): LoadPromptsResult {
+  let stat;
+  try {
+    stat = statSync(promptsDir);
+  } catch {
+    console.warn(
+      `[prompts] Directory not found: ${promptsDir} — using empty prompt`
+    );
+    return { prompt: "", files: [] };
+  }
+
+  if (!stat.isDirectory()) {
+    console.warn(
+      `[prompts] Path is not a directory: ${promptsDir} — using empty prompt`
+    );
+    return { prompt: "", files: [] };
+  }
+
+  const entries = readdirSync(promptsDir)
+    .filter((f) => extname(f).toLowerCase() === ".md")
+    .sort();
+
+  if (entries.length === 0) {
+    console.warn(`[prompts] No .md files found in ${promptsDir}`);
+    return { prompt: "", files: [] };
+  }
+
+  const fragments: string[] = [];
+  for (const file of entries) {
+    try {
+      const content = readFileSync(resolve(promptsDir, file), "utf-8").trim();
+      if (content) {
+        fragments.push(content);
+      }
+    } catch (err) {
+      console.warn(`[prompts] Could not read ${file}, skipping: ${err}`);
+    }
+  }
+
+  console.log(
+    `[prompts] Loaded ${entries.length} file(s): ${entries.join(", ")}`
+  );
+
+  return {
+    prompt: fragments.join("\n\n"),
+    files: entries,
+  };
+}


### PR DESCRIPTION
Add `loadPrompts()` function that scans a `prompts/` directory for `.md` files, reads them in alphabetical order, and concatenates into a system prompt.

Includes 10 unit tests covering edge cases (missing dir, empty dir, unreadable files, non-.md ignored, case-insensitive extensions).

Closes #26
Part of #11